### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ssbarnea @jamesregis


### PR DESCRIPTION
To assure that github allocate a reviewer automatically on pull
requests. Anyone with core access is welcomed to add himself to
that list.