### PR TITLE
Ensure user belongs to libvirt group before any action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ssbarnea @jamesregis

--- a/molecule_libvirt/driver.py
+++ b/molecule_libvirt/driver.py
@@ -18,6 +18,8 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 import os
+import getpass
+import grp
 from molecule import logger
 from molecule.api import Driver
 
@@ -133,18 +135,17 @@ class LibVirt(Driver):
         )
 
     def sanity_checks(self):
-        """Return an exception if user doesn't belong to libvirt group
-        """
+        """Return an exception if user doesn't belong to libvirt group"""
         username = getpass.getuser()
         groups = [group.gr_name for group in grp.getgrall() if username in group.gr_mem]
         try:
-            assert('libvirt' in groups)
+            assert "libvirt" in groups
         except AssertionError:
             util.sysexit_with_message(
-                 "Current user doesn't belong to libvirt group. Running "
-                 "'usermod --append --groups libvirt `whoami`'"
-                 "and 'newgrp libvirt' should fix it."
-             )
+                "Current user doesn't belong to libvirt group. Running "
+                "'usermod --append --groups libvirt `whoami`'"
+                "and 'newgrp libvirt' should fix it."
+            )
 
     def template_dir(self):
         """Return path to its own cookiecutterm templates. It is used by init

--- a/molecule_libvirt/driver.py
+++ b/molecule_libvirt/driver.py
@@ -133,7 +133,18 @@ class LibVirt(Driver):
         )
 
     def sanity_checks(self):
-        pass
+        """Return an exception if user doesn't belong to libvirt group
+        """
+        username = getpass.getuser()
+        groups = [group.gr_name for group in grp.getgrall() if username in group.gr_mem]
+        try:
+            assert('libvirt' in groups)
+        except AssertionError:
+            util.sysexit_with_message(
+                 "Current user doesn't belong to libvirt group. Running "
+                 "'usermod --append --groups libvirt `whoami`'"
+                 "and 'newgrp libvirt' should fix it."
+             )
 
     def template_dir(self):
         """Return path to its own cookiecutterm templates. It is used by init


### PR DESCRIPTION
Will make checks to ensure user belongs to libvirt group. It not, molecule will stop with an error message and the solution.