### PR TITLE
[zuul] Use Python 3.9 with Fedora 34

### DIFF
--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -1,11 +1,11 @@
 - job:
     name: molecule-libvirt-fedora
-    description: Run py38 tox environment
-    parent: ansible-tox-py38
+    description: Run py39 tox environment
+    parent: ansible-tox-py39
     nodeset: fedora-latest-1vcpu
     attempts: 1
     vars:
-      tox_envlist: py38
+      tox_envlist: py39
     timeout: 5400  # 1.5h
 
 - job:


### PR DESCRIPTION
Zuul complains about python38-devel package not available.
Default Python version on Fedora 34 is Python 3.9.

This should fix issue #29.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1205
Depends-On: https://github.com/ansible/ansible/ansible-zuul-jobs#1210