### PR TITLE
Remove ceiling from project dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,10 +64,12 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    molecule >= 3.2.0a0
-    pyyaml >= 5.1, < 6
+    # do not use ceiling unless you already know that newer version breaks
+    # do not use pre-release versions
+    molecule >= 3.4.0
+    pyyaml >= 5.1
     jmespath
-    #libvirt-python
+    # libvirt-python
     lxml
     netaddr
 


### PR DESCRIPTION
This caused conflicts with molecule testing.
